### PR TITLE
adjust code to consistently use value_as_concept_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ curl -d '{"ConceptIds":[2000000324,2000006885]}' -H "Content-Type: application/j
 curl http://localhost:8080/concept-stats/by-source-id/1/by-cohort-definition-id/3/breakdown-by-concept-id/2000007027 | python3 -m json.tool
 curl -d '{"ConceptIds":[2000006885]}'  -H "Content-Type: application/json" -X POST http://localhost:8080/concept-stats/by-source-id/1/by-cohort-definition-id/3/breakdown-by-concept-id/2000007027 | python3 -m json.tool
 
-curl -d '{"ConceptIds":[2000006885]}'  -H "Content-Type: application/json" -X POST http://localhost:8080/cohort-stats/check-overlap/by-source-id/1/by-case-control-cohort-definition-ids/2/3/filter-by-concept-id-and-value/2000007027/ASN | python3 -m json.tool
+curl -d '{"ConceptIds":[2000006885]}'  -H "Content-Type: application/json" -X POST http://localhost:8080/cohort-stats/check-overlap/by-source-id/1/by-case-control-cohort-definition-ids/2/3/filter-by-concept-id-and-value/2000007027/2000007029 | python3 -m json.tool
 
 ```
 

--- a/controllers/cohortdata.go
+++ b/controllers/cohortdata.go
@@ -161,11 +161,11 @@ func (u CohortDataController) RetrieveCohortOverlapStats(c *gin.Context) {
 	errors := make([]error, 5)
 	var sourceId, caseCohortId, controlCohortId int
 	var filterConceptId int64
-	var filterConceptValue string
+	var filterConceptValue int64
 	var conceptIds []int64
 	sourceId, conceptIds, errors[0] = utils.ParseSourceIdAndConceptIds(c)
 	filterConceptId, errors[1] = utils.ParseBigNumericArg(c, "filterconceptid")
-	filterConceptValue, errors[2] = utils.ParseStringArg(c, "filtervalue")
+	filterConceptValue, errors[2] = utils.ParseBigNumericArg(c, "filtervalue")
 	caseCohortId, errors[3] = utils.ParseNumericArg(c, "casecohortid")
 	controlCohortId, errors[4] = utils.ParseNumericArg(c, "controlcohortid")
 	if utils.ContainsNonNil(errors) {

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -1187,7 +1187,7 @@ components:
       in: path
       required: true
       schema:
-        type: string
+        type: number
     breakdownconceptid:
       name: breakdownconceptid
       in: path

--- a/tests/controllers_tests/controllers_test.go
+++ b/tests/controllers_tests/controllers_test.go
@@ -70,7 +70,7 @@ func (h dummyCohortDataModel) RetrieveDataBySourceIdAndCohortIdAndConceptIdsOrde
 }
 
 func (h dummyCohortDataModel) RetrieveCohortOverlapStats(sourceId int, caseCohortId int, controlCohortId int,
-	filterConceptId int64, filterConceptValue string, otherFilterConceptIds []int64) (models.CohortOverlapStats, error) {
+	filterConceptId int64, filterConceptValue int64, otherFilterConceptIds []int64) (models.CohortOverlapStats, error) {
 	var zeroOverlap models.CohortOverlapStats
 	return zeroOverlap, nil
 }
@@ -202,7 +202,7 @@ func TestRetrieveCohortOverlapStats(t *testing.T) {
 	requestContext := new(gin.Context)
 	requestContext.Params = append(requestContext.Params, gin.Param{Key: "sourceid", Value: strconv.Itoa(tests.GetTestSourceId())})
 	requestContext.Params = append(requestContext.Params, gin.Param{Key: "filterconceptid", Value: "1"})
-	requestContext.Params = append(requestContext.Params, gin.Param{Key: "filtervalue", Value: "TEST"})
+	requestContext.Params = append(requestContext.Params, gin.Param{Key: "filtervalue", Value: "123"})
 	requestContext.Params = append(requestContext.Params, gin.Param{Key: "casecohortid", Value: "1"})
 	requestContext.Params = append(requestContext.Params, gin.Param{Key: "controlcohortid", Value: "2"})
 	requestContext.Writer = new(tests.CustomResponseWriter)

--- a/tests/models_tests/models_test.go
+++ b/tests/models_tests/models_test.go
@@ -19,6 +19,7 @@ var largestCohort *models.CohortDefinitionStats
 var allConceptIds []int64
 var genderConceptId = tests.GetTestGenderConceptId()
 var hareConceptId = tests.GetTestHareConceptId()
+var asnHareConceptId = tests.GetTestAsnHareConceptId()
 
 func TestMain(m *testing.M) {
 	setupSuite()
@@ -333,13 +334,13 @@ func TestErrorForRetrieveDataBySourceIdAndCohortIdAndConceptIdsOrderedByPersonId
 }
 
 // for given source and cohort, counts how many persons have the given HARE value
-func getNrPersonsWithHareConceptValue(sourceId int, cohortId int, hareConceptValue string) int64 {
+func getNrPersonsWithHareConceptValue(sourceId int, cohortId int, hareConceptValue int64) int64 {
 	conceptIds := make([]int64, 1)
 	conceptIds[0] = hareConceptId
 	personLevelData, _ := cohortDataModel.RetrieveDataBySourceIdAndCohortIdAndConceptIdsOrderedByPersonId(sourceId, cohortId, conceptIds)
 	var count int64 = 0
 	for _, personLevelDatum := range personLevelData {
-		if personLevelDatum.ConceptValueAsString == hareConceptValue {
+		if personLevelDatum.ConceptValueAsConceptId == hareConceptValue {
 			count++
 		}
 	}
@@ -352,7 +353,7 @@ func TestRetrieveCohortOverlapStats(t *testing.T) {
 	caseCohortId := largestCohort.Id
 	controlCohortId := largestCohort.Id // to ensure we get some overlap, just repeat the same here...
 	filterConceptId := hareConceptId
-	filterConceptValue := "ASN"
+	filterConceptValue := asnHareConceptId
 	otherFilterConceptIds := make([]int64, 0)
 	stats, _ := cohortDataModel.RetrieveCohortOverlapStats(testSourceId, caseCohortId, controlCohortId,
 		filterConceptId, filterConceptValue, otherFilterConceptIds)
@@ -369,7 +370,7 @@ func TestRetrieveCohortOverlapStatsZeroOverlap(t *testing.T) {
 	caseCohortId := largestCohort.Id
 	controlCohortId := smallestCohort.Id
 	filterConceptId := hareConceptId
-	filterConceptValue := "NON-EXISTING-VALUE" // should result in 0 overlap
+	var filterConceptValue int64 = -1 // should result in 0 overlap
 	otherFilterConceptIds := make([]int64, 0)
 	stats, _ := cohortDataModel.RetrieveCohortOverlapStats(testSourceId, caseCohortId, controlCohortId,
 		filterConceptId, filterConceptValue, otherFilterConceptIds)
@@ -384,7 +385,7 @@ func TestRetrieveCohortOverlapStatsZeroOverlapScenario2(t *testing.T) {
 	caseCohortId := largestCohort.Id
 	controlCohortId := largestCohort.Id // to ensure THIS part does not break it, just repeat the same here...
 	filterConceptId := hareConceptId
-	filterConceptValue := "ASN"
+	filterConceptValue := asnHareConceptId
 	// set this list to some dummy non-existing ids:
 	otherFilterConceptIds := make([]int64, 2)
 	otherFilterConceptIds[0] = -1

--- a/tests/testutils.go
+++ b/tests/testutils.go
@@ -26,6 +26,11 @@ func GetTestHareConceptId() int64 {
 	return 2000007027
 }
 
+func GetTestAsnHareConceptId() int64 {
+	// one of the HARE codes, this one being for "ASN-Asian":
+	return 2000007029
+}
+
 func ExecAtlasSQLScript(sqlFilePath string) {
 	ExecSQLScript(sqlFilePath, -1)
 }


### PR DESCRIPTION
Jira Ticket: [PXP-10102](https://ctds-planx.atlassian.net/browse/PXP-10102)

This is needed to make the code consistent now that structured data is used for the the breakdown endpoint since https://github.com/uc-cdis/cohort-middleware/pull/38


### Breaking Changes
- check-overlap endpoint now expects `filtervalue` to be a concept_id (from `observation.value_as_concept_id`)
