### PR TITLE
test(query-timeout): testing adding query timeout to match rds timeout

### DIFF
--- a/utils/dsn.go
+++ b/utils/dsn.go
@@ -20,7 +20,7 @@ func GenerateDsn(sourceConnectionString string) string {
 	username := sourceConnectionParts[7]
 	password := sourceConnectionParts[9]
 
-	dsn := fmt.Sprintf(dbVendor+"://%s:%s@%s:%s?database=%s",
+	dsn := fmt.Sprintf(dbVendor+"://%s:%s@%s:%s?database=%s?queryTimeout=600",
 		username,
 		url.QueryEscape(password),
 		host,


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes
Test adding query timeout to match rds timeout to see if we get around timeout errors with parallel queries

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
