### PR TITLE
New validation method to find duplicated entries in observation table

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -7,3 +7,8 @@ atlas_db:
   password: mysecretpassword # pragma: allowlist secret
   db: postgres
   schema: atlas
+# optional validation config:
+validate:
+  single_observation_for_concept_ids:
+    # HARE concept id:
+    - '2000007027'

--- a/main.go
+++ b/main.go
@@ -2,16 +2,30 @@ package main
 
 import (
 	"flag"
+	"log"
 
 	"github.com/uc-cdis/cohort-middleware/config"
 	"github.com/uc-cdis/cohort-middleware/db"
+	"github.com/uc-cdis/cohort-middleware/models"
 	"github.com/uc-cdis/cohort-middleware/server"
+	"github.com/uc-cdis/cohort-middleware/utils"
 )
+
+func runDataValidation() {
+	conf := config.GetConfig()
+	observationConceptIdsToCheck, _ := utils.SliceAtoi(conf.GetStringSlice("validate.single_observation_for_concept_ids"))
+	var cohortDataModel = new(models.CohortData)
+	nrIssues, _ := cohortDataModel.ValidateObservationData(observationConceptIdsToCheck)
+	if nrIssues > 0 {
+		log.Printf("WARNING: found %d data issues!", nrIssues)
+	}
+}
 
 func main() {
 	environment := flag.String("e", "development", "Environment/prefix of config file name")
 	flag.Parse()
 	config.Init(*environment)
 	db.Init()
+	runDataValidation()
 	server.Init()
 }

--- a/tests/models_tests/models_test.go
+++ b/tests/models_tests/models_test.go
@@ -591,6 +591,36 @@ func TestRetrieveCohortOverlapStatsWithCohortPairs(t *testing.T) {
 	}
 }
 
+func TestValidateObservationData(t *testing.T) {
+	// Tests if we get the expected validation results
+	setUp(t)
+	var cohortDataModel = new(models.CohortData)
+	nrIssues, error := cohortDataModel.ValidateObservationData([]int64{hareConceptId})
+	// we know that the test dataset has at least one patient with more than one HARE:
+	if error != nil {
+		t.Errorf("Did not expect an error, but got %v", error)
+	}
+	if nrIssues == 0 {
+		t.Errorf("Expected validation issues")
+	}
+	nrIssues2, error := cohortDataModel.ValidateObservationData([]int64{456789999}) // some random concept id not in db
+	// we expect no results for a concept that does not exist:
+	if error != nil {
+		t.Errorf("Did not expect an error, but got %v", error)
+	}
+	if nrIssues2 != 0 {
+		t.Errorf("Expected NO validation issues")
+	}
+	nrIssues3, error := cohortDataModel.ValidateObservationData([]int64{})
+	// we expect no results for an empty concept list:
+	if error != nil {
+		t.Errorf("Did not expect an error, but got %v", error)
+	}
+	if nrIssues3 != -1 {
+		t.Errorf("Expected result to be -1")
+	}
+}
+
 func TestGetVersion(t *testing.T) {
 	// mock values (in reality these are set at build time - see Dockerfile "go build" "-ldflags" argument):
 	version.GitCommit = "abc"

--- a/tests/setup_local_db/test_data_results_and_cdm.sql
+++ b/tests/setup_local_db/test_data_results_and_cdm.sql
@@ -11,6 +11,8 @@ values
     (2000000280,'BMI at enrollment','Measurement','Measurement','Measurement','S','2','1970-01-01','2099-12-31',NULL)
 ;
 
+-- TODO - add concept_type_class "concept_class_id" "MVP Continuous" to better reflect real queries?
+
 -- These are the concepts we are looking for in the demo:
 -- 2000006885 - Average height (VALUE_AS_NUMBER)
 -- 2000000323 - MVP Age Group (VALUE_AS_STRING)

--- a/tests/utils_tests/utils_test.go
+++ b/tests/utils_tests/utils_test.go
@@ -121,3 +121,21 @@ func TestGenerateHistogramData(t *testing.T) {
 		t.Errorf("expected %v for histogram but got %v", expectedresult, result)
 	}
 }
+
+func TestSliceAtoi(t *testing.T) {
+	setUp(t)
+	var expectedResult = []int64{
+		1234,
+		5678,
+		2999999997,
+	}
+	result, _ := utils.SliceAtoi([]string{"1234", "5678", "2999999997"})
+	if !reflect.DeepEqual(expectedResult, result) {
+		t.Errorf("Expected %v but found %v", expectedResult, result)
+	}
+
+	_, error := utils.SliceAtoi([]string{"1234", "5678abc", "2999999997"})
+	if error == nil {
+		t.Errorf("Expected an error")
+	}
+}

--- a/utils/parsing.go
+++ b/utils/parsing.go
@@ -52,6 +52,21 @@ func ContainsNonNil(errors []error) bool {
 	return false
 }
 
+// Takes in a list of strings and attempts to transform them to int64,
+// returning the resulting list of int64 values. Will fail if
+// any of the strings cannot be parsed as a number.
+func SliceAtoi(stringValues []string) ([]int64, error) {
+	intValues := make([]int64, 0, len(stringValues))
+	for _, a := range stringValues {
+		i, err := strconv.ParseInt(a, 10, 64)
+		if err != nil {
+			return intValues, err
+		}
+		intValues = append(intValues, i)
+	}
+	return intValues, nil
+}
+
 type ConceptIds struct {
 	ConceptIds []int64
 }


### PR DESCRIPTION
Jira Ticket: [VADC-62](https://ctds-planx.atlassian.net/browse/VADC-62)

### New Features
- New validation method to find duplicated entries in observation table
   - The validation will run for specific concept ids that can now be configured in the config .yaml (example added in this PR)

