### PR TITLE
Fix: change histogram endpoint output to return correct JSON

### DIFF
--- a/tests/utils_tests/utils_test.go
+++ b/tests/utils_tests/utils_test.go
@@ -1,6 +1,7 @@
 package utils_tests
 
 import (
+	"encoding/json"
 	"io"
 	"log"
 	"math"
@@ -116,9 +117,12 @@ func TestFreedmanDiaconis(t *testing.T) {
 func TestGenerateHistogramData(t *testing.T) {
 	setUp(t)
 	expectedresult := `[{"start":6,"end":31.18008152926611,"nr_persons":3},{"start":31.18008152926611,"end":56.36016305853222,"nr_persons":8}]`
-	result := utils.GenerateHistogramData(testData)
-	if result != expectedresult {
-		t.Errorf("expected %v for histogram but got %v", expectedresult, result)
+	resultArray := utils.GenerateHistogramData(testData)
+	resultJson, _ := json.Marshal(resultArray)
+	resultString := string(resultJson)
+
+	if resultString != expectedresult {
+		t.Errorf("expected %v for histogram but got %v", expectedresult, resultString)
 	}
 }
 

--- a/utils/histogram.go
+++ b/utils/histogram.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"encoding/json"
 	"log"
 	"math"
 	"sort"
@@ -15,10 +14,10 @@ type HistogramColumn struct {
 	NumberOfPeople int     `json:"nr_persons"`
 }
 
-func GenerateHistogramData(conceptValues []float64) string {
+func GenerateHistogramData(conceptValues []float64) []HistogramColumn {
 
 	if len(conceptValues) == 0 {
-		return ""
+		return nil
 	}
 
 	sort.Float64s(conceptValues)
@@ -56,8 +55,7 @@ func GenerateHistogramData(conceptValues []float64) string {
 		histogram = append(histogram, binIndexToHistogramColumn[binIndex])
 	}
 
-	histogramJson, _ := json.Marshal(histogram)
-	return string(histogramJson)
+	return histogram
 }
 
 // This function returns the bin width upon the Freedman Diaconis formula: https://en.wikipedia.org/wiki/Freedman%E2%80%93Diaconis_rule


### PR DESCRIPTION
Jira Ticket: [VADC-380](https://ctds-planx.atlassian.net/browse/VADC-380)

### Bug Fixes
- Fixes histogram data endpoint to return correct JSON format for the array of "histogram bin" objects
