### PR TITLE
Fix: use INTERSECT around the UNION of each pair

### DIFF
--- a/models/helper.go
+++ b/models/helper.go
@@ -57,17 +57,15 @@ func QueryFilterByCohortPairsHelper(filterCohortPairs []utils.CustomDichotomousV
 	idsList = append(idsList, cohortDefinitionId)
 	if len(filterCohortPairs) > 0 {
 		// INTERSECT UNIONs section:
-		unionAndIntersectSQL = unionAndIntersectSQL + "INTERSECT ("
-		for i, filterCohortPair := range filterCohortPairs {
+		for _, filterCohortPair := range filterCohortPairs {
 			unionAndIntersectSQL = unionAndIntersectSQL +
-				"SELECT subject_id FROM " + resultsDataSource.Schema + ".cohort WHERE cohort_definition_id=? UNION " +
-				"SELECT subject_id FROM " + resultsDataSource.Schema + ".cohort WHERE cohort_definition_id=? "
-			if i+1 < len(filterCohortPairs) {
-				unionAndIntersectSQL = unionAndIntersectSQL + " UNION "
-			}
+				"INTERSECT ( " +
+				"SELECT subject_id FROM " + resultsDataSource.Schema + ".cohort WHERE cohort_definition_id=? " +
+				"UNION " +
+				"SELECT subject_id FROM " + resultsDataSource.Schema + ".cohort WHERE cohort_definition_id=? " +
+				")"
 			idsList = append(idsList, filterCohortPair.CohortId1, filterCohortPair.CohortId2)
 		}
-		unionAndIntersectSQL = unionAndIntersectSQL + ") "
 		// EXCEPTs section:
 		for _, filterCohortPair := range filterCohortPairs {
 			unionAndIntersectSQL = unionAndIntersectSQL +

--- a/tests/setup_local_db/test_data_results_and_cdm.sql
+++ b/tests/setup_local_db/test_data_results_and_cdm.sql
@@ -121,7 +121,8 @@ values
     (nextval('observation_id_seq'),          7,           2000007027,           2000007028,            'HIS',           'HIS',                    38000276),
     (nextval('observation_id_seq'),          8,           2000007027,           2000007029,            'ASN',           'ASN',                    38000276),
     (nextval('observation_id_seq'),          9,           2000007027,           2000007031,            'EUR',           'EUR',                    38000276),
-    (nextval('observation_id_seq'),         10,           2000007027,           2000007030,            'AFR',           'AFR',                    38000276)
+    (nextval('observation_id_seq'),         10,           2000007027,           2000007030,            'AFR',           'AFR',                    38000276),
+    (nextval('observation_id_seq'),         11,           2000007027,           2000007030,            'AFR',           'AFR',                    38000276)
 ;
 
 -- ========================================================


### PR DESCRIPTION
Jira Ticket: [VADC-422](https://ctds-planx.atlassian.net/browse/VADC-422)

### Bug Fixes
- use INTERSECT around the UNION of each pair to correctly narrow down the result set with the addition of each extra pair to the query
- also improved one of the tests to avoid this specific issue/bug in the future. The test successfully fails with old code and passes with the new one in this PR
 


[VADC-422]: https://ctds-planx.atlassian.net/browse/VADC-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ