### PR TITLE
feat: extra tests for QueryFilterByCohortPairsHelper

### DIFF
--- a/tests/testutils.go
+++ b/tests/testutils.go
@@ -79,6 +79,12 @@ func GetOmopDataSource() *utils.DbAndSchema {
 	return omopDataSource
 }
 
+func GetResultsDataSource() *utils.DbAndSchema {
+	var dataSourceModel = new(models.Source)
+	dataSource := dataSourceModel.GetDataSource(GetTestSourceId(), models.Results)
+	return dataSource
+}
+
 func GetSchemaNameForType(sourceType models.SourceType) string {
 	sourceModel := new(models.Source)
 	dbSchema, _ := sourceModel.GetSourceSchemaNameBySourceIdAndSourceType(GetTestSourceId(), sourceType)


### PR DESCRIPTION
Jira Ticket: [VADC-421](https://ctds-planx.atlassian.net/browse/VADC-421)

### Improvements
- more unit tests for `QueryFilterByCohortPairsHelper`


[VADC-421]: https://ctds-planx.atlassian.net/browse/VADC-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ