### PR TITLE
Fix: adjust populateConceptValue to read values based on conceptClassId

### DIFF
--- a/controllers/cohortdata.go
+++ b/controllers/cohortdata.go
@@ -53,7 +53,7 @@ func (u CohortDataController) RetrieveHistogramForCohortIdAndConceptId(c *gin.Co
 
 	conceptValues := []float64{}
 	for _, personData := range cohortData {
-		conceptValues = append(conceptValues, float64(personData.ConceptValueAsNumber))
+		conceptValues = append(conceptValues, float64(*personData.ConceptValueAsNumber))
 	}
 
 	histogramData := utils.GenerateHistogramData(conceptValues)
@@ -206,10 +206,15 @@ func populateConceptValue(row []string, cohortItem models.PersonConceptAndValue,
 	if conceptIdIdx != -1 {
 		// conceptIdIdx+1 because first column is sample.id:
 		conceptIdxInRow := conceptIdIdx + 1
-		if cohortItem.ConceptValueAsString != "" {
-			row[conceptIdxInRow] = cohortItem.ConceptValueAsString
-		} else if cohortItem.ConceptValueAsNumber != 0.0 {
-			row[conceptIdxInRow] = strconv.FormatFloat(float64(cohortItem.ConceptValueAsNumber), 'f', 2, 64)
+		if cohortItem.ConceptClassId == "MVP Continuous" {
+			if cohortItem.ConceptValueAsNumber != nil {
+				row[conceptIdxInRow] = strconv.FormatFloat(float64(*cohortItem.ConceptValueAsNumber), 'f', 2, 64)
+			}
+		} else {
+			// default to the value as string for now:
+			if cohortItem.ConceptValueAsString != "" {
+				row[conceptIdxInRow] = cohortItem.ConceptValueAsString
+			}
 		}
 	}
 	return row

--- a/models/cohortdata.go
+++ b/models/cohortdata.go
@@ -19,8 +19,9 @@ type CohortData struct{}
 type PersonConceptAndValue struct {
 	PersonId                int64
 	ConceptId               int64
+	ConceptClassId          string
 	ConceptValueAsString    string
-	ConceptValueAsNumber    float32
+	ConceptValueAsNumber    *float32
 	ConceptValueAsConceptId int64
 }
 
@@ -68,8 +69,9 @@ func (h CohortData) RetrieveDataBySourceIdAndCohortIdAndConceptIdsOrderedByPerso
 	// get the observations for the subjects and the concepts, to build up the data rows to return:
 	var cohortData []*PersonConceptAndValue
 	meta_result := omopDataSource.Db.Table(omopDataSource.Schema+".observation_continuous as observation"+omopDataSource.GetViewDirective()).
-		Select("observation.person_id, observation.observation_concept_id as concept_id, observation.value_as_string as concept_value_as_string, observation.value_as_number as concept_value_as_number, observation.value_as_concept_id as concept_value_as_concept_id").
+		Select("observation.person_id, observation.observation_concept_id as concept_id, concept.concept_class_id, observation.value_as_string as concept_value_as_string, observation.value_as_number as concept_value_as_number, observation.value_as_concept_id as concept_value_as_concept_id").
 		Joins("INNER JOIN "+resultsDataSource.Schema+".cohort as cohort ON cohort.subject_id = observation.person_id").
+		Joins("INNER JOIN "+omopDataSource.Schema+".concept as concept ON concept.concept_id = observation.observation_concept_id").
 		Where("cohort.cohort_definition_id = ?", cohortDefinitionId).
 		Where("observation.observation_concept_id in (?)", conceptIds).
 		Order("observation.person_id asc"). // this order is important!

--- a/tests/models_tests/models_test.go
+++ b/tests/models_tests/models_test.go
@@ -686,6 +686,8 @@ func TestRetrieveDataBySourceIdAndCohortIdAndConceptIdsOrderedByPersonId(t *test
 	cohortDefinitions, _ := cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId)
 	var sumNumeric float32 = 0
 	textConcat := ""
+	classIdConcat := ""
+	foundConceptValueAsNumberAsNil := false
 	for _, cohortDefinition := range cohortDefinitions {
 
 		cohortData, _ := cohortDataModel.RetrieveDataBySourceIdAndCohortIdAndConceptIdsOrderedByPersonId(
@@ -702,8 +704,13 @@ func TestRetrieveDataBySourceIdAndCohortIdAndConceptIdsOrderedByPersonId(t *test
 				t.Errorf("Data not ordered by person_id!")
 			}
 			previousPersonId = cohortDatum.PersonId
-			sumNumeric += cohortDatum.ConceptValueAsNumber
+			if cohortDatum.ConceptValueAsNumber != nil {
+				sumNumeric += *cohortDatum.ConceptValueAsNumber
+			} else {
+				foundConceptValueAsNumberAsNil = true
+			}
 			textConcat += cohortDatum.ConceptValueAsString
+			classIdConcat += cohortDatum.ConceptClassId
 		}
 	}
 	// check for data: sum of all numeric values > 0
@@ -714,6 +721,15 @@ func TestRetrieveDataBySourceIdAndCohortIdAndConceptIdsOrderedByPersonId(t *test
 	if textConcat == "" {
 		t.Errorf("Expected some string cohort data")
 	}
+	// check for data: some concepts have class id, so this should not be empty
+	if classIdConcat == "" {
+		t.Errorf("Expected query to return concept class id information")
+	}
+	// check if some numeric values were nil as expected:
+	if foundConceptValueAsNumberAsNil == false {
+		t.Errorf("Expected query to return some nil values for ConceptValueAsNumber")
+	}
+
 }
 
 func TestErrorForRetrieveDataBySourceIdAndCohortIdAndConceptIdsOrderedByPersonId(t *testing.T) {


### PR DESCRIPTION
Jira Ticket: [VADC-488](https://ctds-planx.atlassian.net/browse/VADC-488)

### Bug Fixes
- Fixed CSV endpoint to consider all concepts as numeric/continuous concepts since we don't support values as strings


[VADC-488]: https://ctds-planx.atlassian.net/browse/VADC-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ