### PR TITLE
Fix cohort listing and improve existing warning on startup

### DIFF
--- a/models/cohortdata.go
+++ b/models/cohortdata.go
@@ -169,8 +169,8 @@ func (h CohortData) ValidateObservationData(observationConceptIdsToCheck []int64
 			log.Printf("INFO: no issues found in observation table of data source %d.", source.SourceId)
 		} else {
 			log.Printf("WARNING: !!! found a total of %d `person` records with duplicated `observation` entries for one or more concepts "+
-				"where this is not expected (in data source=%d). These are the entries found: %v !!!",
-				len(personConceptAndCount), source.SourceId, personConceptAndCount)
+				"where this is not expected (in data source=%d).",
+				len(personConceptAndCount), source.SourceId)
 			countIssues += len(personConceptAndCount)
 		}
 	}

--- a/tests/testutils.go
+++ b/tests/testutils.go
@@ -55,7 +55,7 @@ func ExecSQLScript(sqlFilePath string, sourceId int) {
 }
 
 func ExecAtlasSQLString(sqlString string) {
-	ExecSQLScript(sqlString, -1)
+	ExecSQLString(sqlString, -1)
 }
 
 func ExecSQLString(sqlString string, sourceId int) {


### PR DESCRIPTION
Jira Ticket: [VADC-507](https://ctds-planx.atlassian.net/browse/VADC-507)


### Bug Fixes
- improve "get all cohort" method so it warns when a `cohort_definition` record is missing when compared to `cohort` table, instead of crashing

### Improvements
-  improve warning regarding duplicated values in `observation` table (this is an already existing check that currently runs on cohort-middleware startup)


[VADC-507]: https://ctds-planx.atlassian.net/browse/VADC-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ