### PR TITLE
Feat: adjust concept.RetrieveAttritionTable to produce rows in new order

### DIFF
--- a/models/concept.go
+++ b/models/concept.go
@@ -8,6 +8,7 @@ import (
 
 type ConceptI interface {
 	RetriveAllBySourceId(sourceId int) ([]*Concept, error)
+	RetrieveInfoBySourceIdAndConceptId(sourceId int, conceptId int64) (*ConceptSimple, error)
 	RetrieveInfoBySourceIdAndConceptIds(sourceId int, conceptIds []int64) ([]*ConceptSimple, error)
 	RetrieveInfoBySourceIdAndConceptTypes(sourceId int, conceptTypes []string) ([]*ConceptSimple, error)
 	RetrieveBreakdownStatsBySourceIdAndCohortId(sourceId int, cohortDefinitionId int, breakdownConceptId int64) ([]*ConceptBreakdown, error)


### PR DESCRIPTION
Jira Ticket: [VADC-614](https://ctds-planx.atlassian.net/browse/VADC-614)

### Breaking Changes
- adjust `concept.RetrieveAttritionTable` to produce rows in new order, where the order of the rows should follow the order of the concept ids and dichotomous pair variables found in the request


[VADC-614]: https://ctds-planx.atlassian.net/browse/VADC-614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ