### PR TITLE
Feat: add "team project" filtering to /cohortdefinition-stats endpoint 

### DIFF
--- a/controllers/cohortdefinition.go
+++ b/controllers/cohortdefinition.go
@@ -62,12 +62,18 @@ func (u CohortDefinitionController) RetriveAll(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"cohort_definitions": cohortDefinitions})
 }
 
-func (u CohortDefinitionController) RetriveStatsBySourceId(c *gin.Context) {
+func (u CohortDefinitionController) RetriveStatsBySourceIdAndTeamProject(c *gin.Context) {
 	// This method returns ALL cohortdefinition entries with cohort size statistics (for a given source)
 
 	sourceId, err1 := utils.ParseNumericArg(c, "sourceid")
+	teamProject := c.Param("teamproject")
+	if teamProject == "" {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Error while parsing request", "error": "team-project is a mandatory parameter but was found to be empty!"})
+		c.Abort()
+		return
+	}
 	if err1 == nil {
-		cohortDefinitionsAndStats, err := u.cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(sourceId)
+		cohortDefinitionsAndStats, err := u.cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(sourceId, teamProject)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"message": "Error retrieving cohortDefinition", "error": err.Error()})
 			c.Abort()

--- a/models/cohortdefinition.go
+++ b/models/cohortdefinition.go
@@ -108,19 +108,15 @@ func (h CohortDefinition) GetAllCohortDefinitionsAndStatsOrderBySizeDesc(sourceI
 				cohortDefinitionStat.CohortSize)
 			continue
 		} else {
-			cohortDefinitionStat.Name = cohortDefinition.Name
-			finalList = append(finalList, cohortDefinitionStat)
-		}
-	}
-	// filter to keep only the allowed ones:
-	filteredFinalList := []*CohortDefinitionStats{}
-	for _, cohortDefinitionStat := range finalList {
-		if utils.Contains(allowedCohortDefinitionIds, cohortDefinitionStat.Id) {
-			filteredFinalList = append(filteredFinalList, cohortDefinitionStat)
+			// filter to keep only the allowed ones:
+			if utils.Contains(allowedCohortDefinitionIds, cohortDefinitionStat.Id) {
+				cohortDefinitionStat.Name = cohortDefinition.Name
+				finalList = append(finalList, cohortDefinitionStat)
+			}
 		}
 	}
 
-	return filteredFinalList, meta_result.Error
+	return finalList, meta_result.Error
 }
 
 func (h CohortDefinition) GetCohortName(cohortId int) (string, error) {

--- a/server/router.go
+++ b/server/router.go
@@ -30,7 +30,7 @@ func NewRouter() *gin.Engine {
 		authorized.GET("/cohortdefinition/by-id/:id", cohortdefinitions.RetriveById)
 		authorized.GET("/cohortdefinition/by-name/:name", cohortdefinitions.RetriveByName)
 		authorized.GET("/cohortdefinitions", cohortdefinitions.RetriveAll)
-		authorized.GET("/cohortdefinition-stats/by-source-id/:sourceid", cohortdefinitions.RetriveStatsBySourceId)
+		authorized.GET("/cohortdefinition-stats/by-source-id/:sourceid/by-team-project/:teamproject", cohortdefinitions.RetriveStatsBySourceIdAndTeamProject)
 
 		// concept endpoints:
 		concepts := controllers.NewConceptController(*new(models.Concept), *new(models.CohortDefinition))

--- a/tests/models_tests/models_test.go
+++ b/tests/models_tests/models_test.go
@@ -599,6 +599,24 @@ func TestGetAllCohortDefinitionsAndStatsOrderBySizeDesc(t *testing.T) {
 		}
 		previousSize = cohortDefinition.CohortSize
 	}
+
+	// some extra tests to cover also the teamProject option for this method:
+	testTeamProject := "teamprojectX"
+	allowedCohortDefinitions, _ := cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId, testTeamProject)
+	if len(allowedCohortDefinitions) != 1 {
+		t.Errorf("Expected teamProject '%s' to have one cohort, but found %d",
+			testTeamProject, len(allowedCohortDefinitions))
+	}
+	if len(cohortDefinitions) <= len(allowedCohortDefinitions) {
+		t.Errorf("Expected list of projects for '%s' to be larger than for %s",
+			defaultTeamProject, testTeamProject)
+	}
+	testTeamProject = "teamprojectNonExisting"
+	allowedCohortDefinitions, _ = cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId, testTeamProject)
+	if len(allowedCohortDefinitions) != 0 {
+		t.Errorf("Expected teamProject '%s' to have NO cohort, but found %d",
+			testTeamProject, len(allowedCohortDefinitions))
+	}
 }
 
 // Tests whether the code deals correctly with the (error) situation where

--- a/tests/models_tests/models_test.go
+++ b/tests/models_tests/models_test.go
@@ -27,6 +27,7 @@ var allConceptIds []int64
 var dummyContinuousConceptId = tests.GetTestDummyContinuousConceptId()
 var hareConceptId = tests.GetTestHareConceptId()
 var histogramConceptId = tests.GetTestHistogramConceptId()
+var defaultTeamProject = "defaultteamproject"
 
 func TestMain(m *testing.M) {
 	setupSuite()
@@ -47,7 +48,7 @@ func setupSuite() {
 
 	// initialize some handy variables to use in tests below:
 	// (see also tests/setup_local_db/test_data_results_and_cdm.sql for these test cohort details)
-	allCohortDefinitions, _ = cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId)
+	allCohortDefinitions, _ = cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId, defaultTeamProject)
 	largestCohort = allCohortDefinitions[0]
 	secondLargestCohort = allCohortDefinitions[2]
 	extendedCopyOfSecondLargestCohort = allCohortDefinitions[1]
@@ -563,11 +564,29 @@ func TestRetrieveBreakdownStatsBySourceIdAndCohortIdWithResultsWithOnePersonTwoH
 	}
 }
 
+func TestGetCohortDefinitionIdsForTeamProject(t *testing.T) {
+	setUp(t)
+	testTeamProject := "teamprojectX"
+	allowedCohortDefinitionIds, _ := cohortDefinitionModel.GetCohortDefinitionIdsForTeamProject(testTeamProject)
+	if len(allowedCohortDefinitionIds) != 1 {
+		t.Errorf("Expected teamProject '%s' to have one cohort, but found %d",
+			testTeamProject, len(allowedCohortDefinitionIds))
+	}
+	// test data is crafted in such a way that the default "team project" has access to all
+	// the cohorts. Check if this is indeed the case:
+	testTeamProject = defaultTeamProject
+	allowedCohortDefinitionIds, _ = cohortDefinitionModel.GetCohortDefinitionIdsForTeamProject(testTeamProject)
+	allCohortDefinitions, _ := cohortDefinitionModel.GetAllCohortDefinitions()
+	if len(allCohortDefinitions) != len(allowedCohortDefinitionIds) && len(allCohortDefinitions) > 1 {
+		t.Errorf("Found %d, expected %d", len(allowedCohortDefinitionIds), len(allCohortDefinitions))
+	}
+}
+
 func TestGetAllCohortDefinitionsAndStatsOrderBySizeDesc(t *testing.T) {
 	setUp(t)
-	cohortDefinitions, _ := cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId)
+	cohortDefinitions, _ := cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId, defaultTeamProject)
 	if len(cohortDefinitions) != len(allCohortDefinitions) {
-		t.Errorf("Found %d", len(cohortDefinitions))
+		t.Errorf("Found %d, expected %d", len(cohortDefinitions), len(allCohortDefinitions))
 	}
 	// check if stats fields are filled and if order is as expected:
 	previousSize := 1000000
@@ -587,7 +606,7 @@ func TestGetAllCohortDefinitionsAndStatsOrderBySizeDesc(t *testing.T) {
 // the situation where a cohort still exists in `cohort` table but not in `cohort_definition`).
 func TestGetAllCohortDefinitionsAndStatsOrderBySizeDescWhenCohortDefinitionIsMissing(t *testing.T) {
 	setUp(t)
-	cohortDefinitions, _ := cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId)
+	cohortDefinitions, _ := cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId, defaultTeamProject)
 	if len(cohortDefinitions) != len(allCohortDefinitions) {
 		t.Errorf("Found %d", len(cohortDefinitions))
 	}
@@ -596,7 +615,7 @@ func TestGetAllCohortDefinitionsAndStatsOrderBySizeDescWhenCohortDefinitionIsMis
 	firstCohort := cohortDefinitions[0]
 	tests.ExecAtlasSQLString(fmt.Sprintf("delete from %s.cohort_definition where id = %d",
 		db.GetAtlasDB().Schema, firstCohort.Id))
-	cohortDefinitions, _ = cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId)
+	cohortDefinitions, _ = cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId, defaultTeamProject)
 	if len(cohortDefinitions) != len(allCohortDefinitions)-1 {
 		t.Errorf("Number of cohor_definition records expected to be %d, found %d",
 			len(allCohortDefinitions)-1, len(cohortDefinitions))
@@ -685,7 +704,7 @@ func TestQueryFilterByConceptIdsHelper(t *testing.T) {
 
 func TestRetrieveDataBySourceIdAndCohortIdAndConceptIdsOrderedByPersonId(t *testing.T) {
 	setUp(t)
-	cohortDefinitions, _ := cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId)
+	cohortDefinitions, _ := cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId, defaultTeamProject)
 	var sumNumeric float32 = 0
 	textConcat := ""
 	classIdConcat := ""
@@ -737,7 +756,7 @@ func TestRetrieveDataBySourceIdAndCohortIdAndConceptIdsOrderedByPersonId(t *test
 func TestErrorForRetrieveDataBySourceIdAndCohortIdAndConceptIdsOrderedByPersonId(t *testing.T) {
 	// Tests if the method returns an error when query fails.
 
-	cohortDefinitions, _ := cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId)
+	cohortDefinitions, _ := cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(testSourceId, defaultTeamProject)
 
 	// break something in the Results schema to cause a query failure in the next method:
 	tests.BreakSomething(models.Results, "cohort", "cohort_definition_id")

--- a/tests/setup_local_db/test_data_atlas.sql
+++ b/tests/setup_local_db/test_data_atlas.sql
@@ -33,7 +33,8 @@ values
     (1,'public',true),
     (1005,'teamprojectX',false),
     (1009,'teamprojectY',false),
-    (3000,'someotherrole',false)
+    (3000,'someotherrole',false),
+    (4000,'defaultteamproject',false)
 ;
 
 insert into atlas.sec_permission
@@ -52,7 +53,10 @@ values
     (1191, 'cohortdefinition:4:version:*:get', 'Get cohort version'),
     (1192, 'cohortdefinition:4:info:get', 'no description'),
     (1193, 'cohortdefinition:4:get', 'Get Cohort Definition by ID'),
-    (1194, 'cohortdefinition:4:version:get', 'Get list of cohort versions')
+    (1194, 'cohortdefinition:4:version:get', 'Get list of cohort versions'),
+    (2193, 'cohortdefinition:1:get', 'Get Cohort Definition by ID'),
+    (3193, 'cohortdefinition:3:get', 'Get Cohort Definition by ID'),
+    (4193, 'cohortdefinition:32:get', 'Get Cohort Definition by ID')
 ;
 
 insert into atlas.sec_role_permission
@@ -71,5 +75,22 @@ values
     (1464, 1009, 1191),
     (1465, 1009, 1192),
     (1466, 1009, 1193),
-    (1467, 1009, 1194)
+    (1467, 1009, 1194),
+    (2454, 4000, 1181),
+    (2455, 4000, 1182),
+    (2456, 4000, 1183),
+    (2457, 4000, 1184),
+    (2458, 4000, 1185),
+    (2459, 4000, 1186),
+    (2460, 4000, 1187),
+    (2461, 4000, 1188),
+    (2462, 4000, 1189),
+    (2463, 4000, 1190),
+    (2464, 4000, 1191),
+    (2465, 4000, 1192),
+    (2466, 4000, 1193),
+    (2467, 4000, 1194),
+    (2468, 4000, 2193),
+    (2469, 4000, 3193),
+    (2470, 4000, 4193)
 ;

--- a/tests/setup_local_db/test_data_atlas.sql
+++ b/tests/setup_local_db/test_data_atlas.sql
@@ -26,3 +26,50 @@ values
     (32,'Test cohort3b','Copy of Larger cohort'),
     (4,'Test cohort4','Extra Larger cohort')
 ;
+
+insert into atlas.sec_role
+    (id, name, system_role)
+values
+    (1,'public',true),
+    (1005,'teamprojectX',false),
+    (1009,'teamprojectY',false),
+    (3000,'someotherrole',false)
+;
+
+insert into atlas.sec_permission
+    (id, value, description)
+values
+    (1181, 'cohortdefinition:2:check:post', 'Fix Cohort Definition with ID = 2'),
+    (1182, 'cohortdefinition:2:put', 'Update Cohort Definition with ID = 2'),
+    (1183, 'cohortdefinition:2:delete', 'Delete Cohort Definition with ID = 2'),
+    (1184, 'cohortdefinition:2:version:*:get', 'Get cohort version'),
+    (1185, 'cohortdefinition:2:info:get', 'no description'),
+    (1186, 'cohortdefinition:2:get', 'Get Cohort Definition by ID'),
+    (1187, 'cohortdefinition:2:version:get', 'Get list of cohort versions'),
+    (1188, 'cohortdefinition:4:check:post', 'Fix Cohort Definition with ID = 4'),
+    (1189, 'cohortdefinition:4:put', 'Update Cohort Definition with ID = 4'),
+    (1190, 'cohortdefinition:4:delete', 'Delete Cohort Definition with ID = 4'),
+    (1191, 'cohortdefinition:4:version:*:get', 'Get cohort version'),
+    (1192, 'cohortdefinition:4:info:get', 'no description'),
+    (1193, 'cohortdefinition:4:get', 'Get Cohort Definition by ID'),
+    (1194, 'cohortdefinition:4:version:get', 'Get list of cohort versions')
+;
+
+insert into atlas.sec_role_permission
+    (id, role_id, permission_id)
+values
+    (1454, 1005, 1181),
+    (1455, 1005, 1182),
+    (1456, 1005, 1183),
+    (1457, 1005, 1184),
+    (1458, 1005, 1185),
+    (1459, 1005, 1186),
+    (1460, 1005, 1187),
+    (1461, 1009, 1188),
+    (1462, 1009, 1189),
+    (1463, 1009, 1190),
+    (1464, 1009, 1191),
+    (1465, 1009, 1192),
+    (1466, 1009, 1193),
+    (1467, 1009, 1194)
+;

--- a/utils/parsing.go
+++ b/utils/parsing.go
@@ -43,6 +43,15 @@ func Pos(value int64, list []int64) int {
 	return -1
 }
 
+func Contains(list []int, value int) bool {
+	for _, item := range list {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
 func ParseInt64(strValue string) int64 {
 	value, error := strconv.ParseInt(strValue, 10, 64)
 	if error != nil {
@@ -52,8 +61,8 @@ func ParseInt64(strValue string) int64 {
 }
 
 func ContainsNonNil(errors []error) bool {
-	for _, v := range errors {
-		if v != nil {
+	for _, item := range errors {
+		if item != nil {
 			return true
 		}
 	}


### PR DESCRIPTION
Jira Ticket: [VADC-618](https://ctds-planx.atlassian.net/browse/VADC-618)


### Breaking Changes
- add "team project" filtering to /cohortdefinition-stats endpoint. This means that the `/cohortdefinition-stats/by-source-id/:sourceid/` got an extra mandatory parameter and looks like this now: `/cohortdefinition-stats/by-source-id/:sourceid/by-team-project/:teamproject`



### Deployment changes
- a new SQL VIEW should be added to the Atlas/WebAPI database that contains the `sec_` tables (see view added to `tests/setup_local_db/ddl_atlas.sql` [and comment here](https://github.com/uc-cdis/cohort-middleware/pull/81#pullrequestreview-1763246774))

[VADC-618]: https://ctds-planx.atlassian.net/browse/VADC-618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ