### PR TITLE
Feat: integrate Arborist validation for team project for cohort data endpoints AND remove unused endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ cd tests/setup_local_db/
 JSON summary data endpoints:
 ```bash
 curl http://localhost:8080/sources | python -m json.tool
-curl http://localhost:8080/cohortdefinition-stats/by-source-id/1 | python -m json.tool
+curl "http://localhost:8080/cohortdefinition-stats/by-source-id/1/by-team-project?team-project=test" | python -m json.tool
 curl http://localhost:8080/concept/by-source-id/1 | python -m json.tool
 curl -d '{"ConceptIds":[2000000324,2000006885]}' -H "Content-Type: application/json" -X POST http://localhost:8080/concept/by-source-id/1 | python -m json.tool
 curl -d '{"ConceptTypes":["Measurement","Person"]}' -H "Content-Type: application/json" -X POST http://localhost:8080/concept/by-source-id/1/by-type | python -m json.tool

--- a/controllers/cohortdata.go
+++ b/controllers/cohortdata.go
@@ -49,8 +49,7 @@ func (u CohortDataController) RetrieveHistogramForCohortIdAndConceptId(c *gin.Co
 	cohortId, _ := strconv.Atoi(cohortIdStr)
 	histogramConceptId, _ := strconv.ParseInt(histogramIdStr, 10, 64)
 
-	uniqueCohortDefinitionIdsList := utils.GetUniqueCohortDefinitionIdsListFromRequest([]int{cohortId}, cohortPairs)
-	validAccessRequest := u.teamProjectAuthz.TeamProjectValidationForCohortIdsList(c, uniqueCohortDefinitionIdsList)
+	validAccessRequest := u.teamProjectAuthz.TeamProjectValidation(c, []int{cohortId}, cohortPairs)
 	if !validAccessRequest {
 		log.Printf("Error: invalid request")
 		c.JSON(http.StatusBadRequest, gin.H{"message": "access denied"})
@@ -99,8 +98,7 @@ func (u CohortDataController) RetrieveDataBySourceIdAndCohortIdAndVariables(c *g
 	sourceId, _ := strconv.Atoi(sourceIdStr)
 	cohortId, _ := strconv.Atoi(cohortIdStr)
 
-	uniqueCohortDefinitionIdsList := utils.GetUniqueCohortDefinitionIdsListFromRequest([]int{cohortId}, cohortPairs)
-	validAccessRequest := u.teamProjectAuthz.TeamProjectValidationForCohortIdsList(c, uniqueCohortDefinitionIdsList)
+	validAccessRequest := u.teamProjectAuthz.TeamProjectValidation(c, []int{cohortId}, cohortPairs)
 	if !validAccessRequest {
 		log.Printf("Error: invalid request")
 		c.JSON(http.StatusBadRequest, gin.H{"message": "access denied"})
@@ -253,8 +251,7 @@ func (u CohortDataController) RetrieveCohortOverlapStatsWithoutFilteringOnConcep
 	controlCohortId, errors[2] = utils.ParseNumericArg(c, "controlcohortid")
 	conceptIds, cohortPairs, errors[3] = utils.ParseConceptIdsAndDichotomousDefs(c)
 
-	uniqueCohortDefinitionIdsList := utils.GetUniqueCohortDefinitionIdsListFromRequest([]int{caseCohortId, controlCohortId}, cohortPairs)
-	validAccessRequest := u.teamProjectAuthz.TeamProjectValidationForCohortIdsList(c, uniqueCohortDefinitionIdsList)
+	validAccessRequest := u.teamProjectAuthz.TeamProjectValidation(c, []int{caseCohortId, controlCohortId}, cohortPairs)
 	if !validAccessRequest {
 		log.Printf("Error: invalid request")
 		c.JSON(http.StatusBadRequest, gin.H{"message": "access denied"})

--- a/controllers/cohortdefinition.go
+++ b/controllers/cohortdefinition.go
@@ -18,9 +18,8 @@ func NewCohortDefinitionController(cohortDefinitionModel models.CohortDefinition
 
 func (u CohortDefinitionController) RetriveStatsBySourceIdAndTeamProject(c *gin.Context) {
 	// This method returns ALL cohortdefinition entries with cohort size statistics (for a given source)
-
 	sourceId, err1 := utils.ParseNumericArg(c, "sourceid")
-	teamProject := c.Param("teamproject")
+	teamProject := c.Query("team-project")
 	if teamProject == "" {
 		c.JSON(http.StatusInternalServerError, gin.H{"message": "Error while parsing request", "error": "team-project is a mandatory parameter but was found to be empty!"})
 		c.Abort()

--- a/controllers/cohortdefinition.go
+++ b/controllers/cohortdefinition.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/uc-cdis/cohort-middleware/models"
@@ -15,51 +14,6 @@ type CohortDefinitionController struct {
 
 func NewCohortDefinitionController(cohortDefinitionModel models.CohortDefinitionI) CohortDefinitionController {
 	return CohortDefinitionController{cohortDefinitionModel: cohortDefinitionModel}
-}
-
-func (u CohortDefinitionController) RetriveById(c *gin.Context) {
-	cohortDefinitionId := c.Param("id")
-
-	if cohortDefinitionId != "" {
-		cohortDefinitionId, _ := strconv.Atoi(cohortDefinitionId)
-		cohortDefinition, err := u.cohortDefinitionModel.GetCohortDefinitionById(cohortDefinitionId)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"message": "Error retrieving cohortDefinition", "error": err.Error()})
-			c.Abort()
-			return
-		}
-		c.JSON(http.StatusOK, gin.H{"cohort_definition": cohortDefinition})
-		return
-	}
-	c.JSON(http.StatusBadRequest, gin.H{"message": "bad request"})
-	c.Abort()
-}
-
-func (u CohortDefinitionController) RetriveByName(c *gin.Context) {
-	cohortDefinitionName := c.Param("name")
-
-	if cohortDefinitionName != "" {
-		cohortDefinition, err := u.cohortDefinitionModel.GetCohortDefinitionByName(cohortDefinitionName)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"message": "Error retrieving cohortDefinition", "error": err.Error()})
-			c.Abort()
-			return
-		}
-		c.JSON(http.StatusOK, gin.H{"CohortDefinition": cohortDefinition})
-		return
-	}
-	c.JSON(http.StatusBadRequest, gin.H{"message": "bad request"})
-	c.Abort()
-}
-
-func (u CohortDefinitionController) RetriveAll(c *gin.Context) {
-	cohortDefinitions, err := u.cohortDefinitionModel.GetAllCohortDefinitions()
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"message": "Error retrieving cohortDefinition", "error": err.Error()})
-		c.Abort()
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"cohort_definitions": cohortDefinitions})
 }
 
 func (u CohortDefinitionController) RetriveStatsBySourceIdAndTeamProject(c *gin.Context) {

--- a/controllers/concept.go
+++ b/controllers/concept.go
@@ -132,7 +132,7 @@ func (u ConceptController) RetrieveBreakdownStatsBySourceIdAndCohortIdAndVariabl
 		c.Abort()
 		return
 	}
-	validAccessRequest := u.teamProjectAuthz.TeamProjectValidation(c, cohortId, cohortPairs)
+	validAccessRequest := u.teamProjectAuthz.TeamProjectValidation(c, []int{cohortId}, cohortPairs)
 	if !validAccessRequest {
 		log.Printf("Error: invalid request")
 		c.JSON(http.StatusBadRequest, gin.H{"message": "access denied"})
@@ -198,7 +198,7 @@ func (u ConceptController) RetrieveAttritionTable(c *gin.Context) {
 		return
 	}
 	_, cohortPairs := utils.GetConceptIdsAndCohortPairsAsSeparateLists(conceptIdsAndCohortPairs)
-	validAccessRequest := u.teamProjectAuthz.TeamProjectValidation(c, cohortId, cohortPairs)
+	validAccessRequest := u.teamProjectAuthz.TeamProjectValidation(c, []int{cohortId}, cohortPairs)
 	if !validAccessRequest {
 		log.Printf("Error: invalid request")
 		c.JSON(http.StatusBadRequest, gin.H{"message": "access denied"})

--- a/middlewares/teamprojectauthz.go
+++ b/middlewares/teamprojectauthz.go
@@ -12,6 +12,7 @@ import (
 type TeamProjectAuthzI interface {
 	TeamProjectValidationForCohort(ctx *gin.Context, cohortDefinitionId int) bool
 	TeamProjectValidation(ctx *gin.Context, cohortDefinitionId int, filterCohortPairs []utils.CustomDichotomousVariableDef) bool
+	TeamProjectValidationForCohortIdsList(ctx *gin.Context, uniqueCohortDefinitionIdsList []int) bool
 }
 
 type HttpClientI interface {
@@ -61,13 +62,17 @@ func (u TeamProjectAuthz) TeamProjectValidationForCohort(ctx *gin.Context, cohor
 	return u.TeamProjectValidation(ctx, cohortDefinitionId, filterCohortPairs)
 }
 
-// "team project" related checks:
-// (1) check if the request contains any cohorts and if all cohorts belong to the same "team project"
-// (2) check if the user has permission in the "team project"
-// Returns true if both checks above pass, false otherwise.
 func (u TeamProjectAuthz) TeamProjectValidation(ctx *gin.Context, cohortDefinitionId int, filterCohortPairs []utils.CustomDichotomousVariableDef) bool {
 
-	uniqueCohortDefinitionIdsList := utils.GetUniqueCohortDefinitionIdsListFromRequest(cohortDefinitionId, filterCohortPairs)
+	uniqueCohortDefinitionIdsList := utils.GetUniqueCohortDefinitionIdsListFromRequest([]int{cohortDefinitionId}, filterCohortPairs)
+	return u.TeamProjectValidationForCohortIdsList(ctx, uniqueCohortDefinitionIdsList)
+}
+
+// "team project" related checks:
+// (1) check if all cohorts belong to the same "team project"
+// (2) check if the user has permission in the "team project"
+// Returns true if both checks above pass, false otherwise.
+func (u TeamProjectAuthz) TeamProjectValidationForCohortIdsList(ctx *gin.Context, uniqueCohortDefinitionIdsList []int) bool {
 	teamProjects, _ := u.cohortDefinitionModel.GetTeamProjectsThatMatchAllCohortDefinitionIds(uniqueCohortDefinitionIdsList)
 	if len(teamProjects) == 0 {
 		log.Printf("Invalid request error: could not find a 'team project' that is associated to ALL the cohorts present in this request")

--- a/middlewares/teamprojectauthz.go
+++ b/middlewares/teamprojectauthz.go
@@ -11,7 +11,7 @@ import (
 
 type TeamProjectAuthzI interface {
 	TeamProjectValidationForCohort(ctx *gin.Context, cohortDefinitionId int) bool
-	TeamProjectValidation(ctx *gin.Context, cohortDefinitionId int, filterCohortPairs []utils.CustomDichotomousVariableDef) bool
+	TeamProjectValidation(ctx *gin.Context, cohortDefinitionIds []int, filterCohortPairs []utils.CustomDichotomousVariableDef) bool
 	TeamProjectValidationForCohortIdsList(ctx *gin.Context, uniqueCohortDefinitionIdsList []int) bool
 }
 
@@ -59,12 +59,12 @@ func (u TeamProjectAuthz) hasAccessToAtLeastOne(ctx *gin.Context, teamProjects [
 
 func (u TeamProjectAuthz) TeamProjectValidationForCohort(ctx *gin.Context, cohortDefinitionId int) bool {
 	filterCohortPairs := []utils.CustomDichotomousVariableDef{}
-	return u.TeamProjectValidation(ctx, cohortDefinitionId, filterCohortPairs)
+	return u.TeamProjectValidation(ctx, []int{cohortDefinitionId}, filterCohortPairs)
 }
 
-func (u TeamProjectAuthz) TeamProjectValidation(ctx *gin.Context, cohortDefinitionId int, filterCohortPairs []utils.CustomDichotomousVariableDef) bool {
+func (u TeamProjectAuthz) TeamProjectValidation(ctx *gin.Context, cohortDefinitionIds []int, filterCohortPairs []utils.CustomDichotomousVariableDef) bool {
 
-	uniqueCohortDefinitionIdsList := utils.GetUniqueCohortDefinitionIdsListFromRequest([]int{cohortDefinitionId}, filterCohortPairs)
+	uniqueCohortDefinitionIdsList := utils.GetUniqueCohortDefinitionIdsListFromRequest(cohortDefinitionIds, filterCohortPairs)
 	return u.TeamProjectValidationForCohortIdsList(ctx, uniqueCohortDefinitionIdsList)
 }
 

--- a/server/router.go
+++ b/server/router.go
@@ -29,9 +29,6 @@ func NewRouter() *gin.Engine {
 		authorized.GET("/sources", source.RetriveAll)
 
 		cohortdefinitions := controllers.NewCohortDefinitionController(*new(models.CohortDefinition))
-		authorized.GET("/cohortdefinition/by-id/:id", cohortdefinitions.RetriveById)
-		authorized.GET("/cohortdefinition/by-name/:name", cohortdefinitions.RetriveByName)
-		authorized.GET("/cohortdefinitions", cohortdefinitions.RetriveAll)
 		authorized.GET("/cohortdefinition-stats/by-source-id/:sourceid/by-team-project/:teamproject", cohortdefinitions.RetriveStatsBySourceIdAndTeamProject)
 
 		// concept endpoints:

--- a/server/router.go
+++ b/server/router.go
@@ -46,7 +46,7 @@ func NewRouter() *gin.Engine {
 		authorized.POST("/concept-stats/by-source-id/:sourceid/by-cohort-definition-id/:cohortid/breakdown-by-concept-id/:breakdownconceptid/csv", concepts.RetrieveAttritionTable)
 
 		// cohort stats and checks:
-		cohortData := controllers.NewCohortDataController(*new(models.CohortData))
+		cohortData := controllers.NewCohortDataController(*new(models.CohortData), middlewares.NewTeamProjectAuthz(*new(models.CohortDefinition), &http.Client{}))
 		// :casecohortid/:controlcohortid are just labels here and have no special meaning. Could also just be :cohortAId/:cohortBId here:
 		authorized.POST("/cohort-stats/check-overlap/by-source-id/:sourceid/by-cohort-definition-ids/:casecohortid/:controlcohortid", cohortData.RetrieveCohortOverlapStatsWithoutFilteringOnConceptValue)
 

--- a/server/router.go
+++ b/server/router.go
@@ -29,7 +29,7 @@ func NewRouter() *gin.Engine {
 		authorized.GET("/sources", source.RetriveAll)
 
 		cohortdefinitions := controllers.NewCohortDefinitionController(*new(models.CohortDefinition))
-		authorized.GET("/cohortdefinition-stats/by-source-id/:sourceid/by-team-project/:teamproject", cohortdefinitions.RetriveStatsBySourceIdAndTeamProject)
+		authorized.GET("/cohortdefinition-stats/by-source-id/:sourceid/by-team-project", cohortdefinitions.RetriveStatsBySourceIdAndTeamProject)
 
 		// concept endpoints:
 		concepts := controllers.NewConceptController(*new(models.Concept), *new(models.CohortDefinition),

--- a/tests/controllers_tests/controllers_test.go
+++ b/tests/controllers_tests/controllers_test.go
@@ -478,45 +478,6 @@ func TestRetriveStatsBySourceIdAndTeamProject(t *testing.T) {
 	}
 }
 
-func TestRetriveByIdWrongParam(t *testing.T) {
-	setUp(t)
-	requestContext := new(gin.Context)
-	requestContext.Params = append(requestContext.Params, gin.Param{Key: "Abc", Value: "def"})
-	requestContext.Writer = new(tests.CustomResponseWriter)
-	cohortDefinitionController.RetriveById(requestContext)
-	// Params above are wrong, so request should abort:
-	if !requestContext.IsAborted() {
-		t.Errorf("Expected aborted request")
-	}
-}
-
-func TestRetriveById(t *testing.T) {
-	setUp(t)
-	requestContext := new(gin.Context)
-	requestContext.Params = append(requestContext.Params, gin.Param{Key: "id", Value: "1"})
-	requestContext.Writer = new(tests.CustomResponseWriter)
-	cohortDefinitionController.RetriveById(requestContext)
-	result := requestContext.Writer.(*tests.CustomResponseWriter)
-	log.Printf("result: %s", result)
-	// expect result with dummy data:
-	if !strings.Contains(result.CustomResponseWriterOut, "test 1") {
-		t.Errorf("Expected data in result")
-	}
-}
-
-func TestRetriveByIdModelError(t *testing.T) {
-	setUp(t)
-	requestContext := new(gin.Context)
-	requestContext.Params = append(requestContext.Params, gin.Param{Key: "id", Value: "1"})
-	requestContext.Writer = new(tests.CustomResponseWriter)
-	// set flag to let mock model layer return error instead of mock data:
-	dummyModelReturnError = true
-	cohortDefinitionController.RetriveById(requestContext)
-	if !requestContext.IsAborted() {
-		t.Errorf("Expected aborted request")
-	}
-}
-
 func TestRetrieveBreakdownStatsBySourceIdAndCohortId(t *testing.T) {
 	setUp(t)
 	requestContext := new(gin.Context)

--- a/tests/controllers_tests/controllers_test.go
+++ b/tests/controllers_tests/controllers_test.go
@@ -142,7 +142,7 @@ func (h dummyTeamProjectAuthz) TeamProjectValidationForCohort(ctx *gin.Context, 
 	return true
 }
 
-func (h dummyTeamProjectAuthz) TeamProjectValidation(ctx *gin.Context, cohortDefinitionId int, filterCohortPairs []utils.CustomDichotomousVariableDef) bool {
+func (h dummyTeamProjectAuthz) TeamProjectValidation(ctx *gin.Context, cohortDefinitionIds []int, filterCohortPairs []utils.CustomDichotomousVariableDef) bool {
 	return true
 }
 
@@ -156,7 +156,7 @@ func (h dummyFailingTeamProjectAuthz) TeamProjectValidationForCohort(ctx *gin.Co
 	return false
 }
 
-func (h dummyFailingTeamProjectAuthz) TeamProjectValidation(ctx *gin.Context, cohortDefinitionId int, filterCohortPairs []utils.CustomDichotomousVariableDef) bool {
+func (h dummyFailingTeamProjectAuthz) TeamProjectValidation(ctx *gin.Context, cohortDefinitionIds []int, filterCohortPairs []utils.CustomDichotomousVariableDef) bool {
 	return false
 }
 

--- a/tests/middlewares_tests/middlewares_test.go
+++ b/tests/middlewares_tests/middlewares_test.go
@@ -134,7 +134,7 @@ func TestTeamProjectValidation(t *testing.T) {
 	requestContext.Request.Header = map[string][]string{
 		"Authorization": {"dummy_token_value"},
 	}
-	result := teamProjectAuthz.TeamProjectValidation(requestContext, 1, nil)
+	result := teamProjectAuthz.TeamProjectValidation(requestContext, []int{1}, nil)
 	if result == false {
 		t.Errorf("Expected TeamProjectValidation result to be 'true'")
 	}
@@ -155,7 +155,7 @@ func TestTeamProjectValidationArborist401(t *testing.T) {
 	requestContext.Request.Header = map[string][]string{
 		"Authorization": {"dummy_token_value"},
 	}
-	result := teamProjectAuthz.TeamProjectValidation(requestContext, 1, nil)
+	result := teamProjectAuthz.TeamProjectValidation(requestContext, []int{1}, nil)
 	if result == true {
 		t.Errorf("Expected TeamProjectValidation result to be 'false'")
 	}
@@ -176,7 +176,7 @@ func TestTeamProjectValidationNoTeamProjectMatchingAllCohortDefinitions(t *testi
 	requestContext.Request.Header = map[string][]string{
 		"Authorization": {"dummy_token_value"},
 	}
-	result := teamProjectAuthz.TeamProjectValidation(requestContext, 0, nil)
+	result := teamProjectAuthz.TeamProjectValidation(requestContext, []int{0}, nil)
 	if result == true {
 		t.Errorf("Expected TeamProjectValidation result to be 'false'")
 	}

--- a/tests/models_tests/models_test.go
+++ b/tests/models_tests/models_test.go
@@ -573,7 +573,7 @@ func TestGetTeamProjectsThatMatchAllCohortDefinitionIdsOnlyDefaultMatch(t *testi
 			CohortDefinitionId2: largestCohort.Id,
 			ProvidedName:        "test"},
 	}
-	uniqueCohortDefinitionIdsList := utils.GetUniqueCohortDefinitionIdsListFromRequest(cohortDefinitionId, filterCohortPairs)
+	uniqueCohortDefinitionIdsList := utils.GetUniqueCohortDefinitionIdsListFromRequest([]int{cohortDefinitionId}, filterCohortPairs)
 	teamProjects, _ := cohortDefinitionModel.GetTeamProjectsThatMatchAllCohortDefinitionIds(uniqueCohortDefinitionIdsList)
 	if len(teamProjects) != 1 || teamProjects[0] != "defaultteamproject" {
 		t.Errorf("Expected to find only defaultteamproject")
@@ -589,7 +589,7 @@ func TestGetTeamProjectsThatMatchAllCohortDefinitionIds(t *testing.T) {
 			CohortDefinitionId2: 2,
 			ProvidedName:        "test"},
 	}
-	uniqueCohortDefinitionIdsList := utils.GetUniqueCohortDefinitionIdsListFromRequest(cohortDefinitionId, filterCohortPairs)
+	uniqueCohortDefinitionIdsList := utils.GetUniqueCohortDefinitionIdsListFromRequest([]int{cohortDefinitionId}, filterCohortPairs)
 	teamProjects, _ := cohortDefinitionModel.GetTeamProjectsThatMatchAllCohortDefinitionIds(uniqueCohortDefinitionIdsList)
 	if len(teamProjects) != 2 {
 		t.Errorf("Expected to find two 'team projects' matching the cohort list, found %s", teamProjects)

--- a/utils/parsing.go
+++ b/utils/parsing.go
@@ -289,9 +289,9 @@ func MakeUnique(input []int) []int {
 	return uniqueList
 }
 
-func GetUniqueCohortDefinitionIdsListFromRequest(cohortDefinitionId int, filterCohortPairs []CustomDichotomousVariableDef) []int {
+func GetUniqueCohortDefinitionIdsListFromRequest(cohortDefinitionIds []int, filterCohortPairs []CustomDichotomousVariableDef) []int {
 	var idsList []int
-	idsList = append(idsList, cohortDefinitionId)
+	idsList = append(idsList, cohortDefinitionIds...)
 	if len(filterCohortPairs) > 0 {
 		for _, filterCohortPair := range filterCohortPairs {
 			idsList = append(idsList, filterCohortPair.CohortDefinitionId1, filterCohortPair.CohortDefinitionId2)


### PR DESCRIPTION
Jira Ticket: [VADC-839](https://ctds-planx.atlassian.net/browse/VADC-839)

### New Features
- Add "team project" validation for cohort-middleware cohortData endpoints. This validation is basically an extra authorization validation that checks if cohort access (for any cohorts in variables) is granted to the user through one of his team projects    

### Bug Fixes
- Fix the endpoint `/cohortdefinition-stats/by-source-id/:sourceid/by-team-project` to support a URL query parameter where the "team project" can also start with `/`

### Breaking Changes
- Removed some endpoints that are NOT used by our current frontend. This will break for any clients that happen to use them. This was preferred over implementing extra "team project" validation for endpoints we're not using anyway.


[VADC-839]: https://ctds-planx.atlassian.net/browse/VADC-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ