### PR TITLE
Feat/add missing arborist checks

### DIFF
--- a/controllers/cohortdata.go
+++ b/controllers/cohortdata.go
@@ -52,7 +52,7 @@ func (u CohortDataController) RetrieveHistogramForCohortIdAndConceptId(c *gin.Co
 	validAccessRequest := u.teamProjectAuthz.TeamProjectValidation(c, []int{cohortId}, cohortPairs)
 	if !validAccessRequest {
 		log.Printf("Error: invalid request")
-		c.JSON(http.StatusBadRequest, gin.H{"message": "access denied"})
+		c.JSON(http.StatusForbidden, gin.H{"message": "access denied"})
 		c.Abort()
 		return
 	}
@@ -101,7 +101,7 @@ func (u CohortDataController) RetrieveDataBySourceIdAndCohortIdAndVariables(c *g
 	validAccessRequest := u.teamProjectAuthz.TeamProjectValidation(c, []int{cohortId}, cohortPairs)
 	if !validAccessRequest {
 		log.Printf("Error: invalid request")
-		c.JSON(http.StatusBadRequest, gin.H{"message": "access denied"})
+		c.JSON(http.StatusForbidden, gin.H{"message": "access denied"})
 		c.Abort()
 		return
 	}
@@ -254,7 +254,7 @@ func (u CohortDataController) RetrieveCohortOverlapStatsWithoutFilteringOnConcep
 	validAccessRequest := u.teamProjectAuthz.TeamProjectValidation(c, []int{caseCohortId, controlCohortId}, cohortPairs)
 	if !validAccessRequest {
 		log.Printf("Error: invalid request")
-		c.JSON(http.StatusBadRequest, gin.H{"message": "access denied"})
+		c.JSON(http.StatusForbidden, gin.H{"message": "access denied"})
 		c.Abort()
 		return
 	}

--- a/controllers/concept.go
+++ b/controllers/concept.go
@@ -102,7 +102,7 @@ func (u ConceptController) RetrieveBreakdownStatsBySourceIdAndCohortId(c *gin.Co
 	validAccessRequest := u.teamProjectAuthz.TeamProjectValidationForCohort(c, cohortId)
 	if !validAccessRequest {
 		log.Printf("Error: invalid request")
-		c.JSON(http.StatusBadRequest, gin.H{"message": "access denied"})
+		c.JSON(http.StatusForbidden, gin.H{"message": "access denied"})
 		c.Abort()
 		return
 	}
@@ -135,7 +135,7 @@ func (u ConceptController) RetrieveBreakdownStatsBySourceIdAndCohortIdAndVariabl
 	validAccessRequest := u.teamProjectAuthz.TeamProjectValidation(c, []int{cohortId}, cohortPairs)
 	if !validAccessRequest {
 		log.Printf("Error: invalid request")
-		c.JSON(http.StatusBadRequest, gin.H{"message": "access denied"})
+		c.JSON(http.StatusForbidden, gin.H{"message": "access denied"})
 		c.Abort()
 		return
 	}
@@ -201,7 +201,7 @@ func (u ConceptController) RetrieveAttritionTable(c *gin.Context) {
 	validAccessRequest := u.teamProjectAuthz.TeamProjectValidation(c, []int{cohortId}, cohortPairs)
 	if !validAccessRequest {
 		log.Printf("Error: invalid request")
-		c.JSON(http.StatusBadRequest, gin.H{"message": "access denied"})
+		c.JSON(http.StatusForbidden, gin.H{"message": "access denied"})
 		c.Abort()
 		return
 	}

--- a/server/router.go
+++ b/server/router.go
@@ -28,7 +28,8 @@ func NewRouter() *gin.Engine {
 		authorized.GET("/source/by-name/:name", source.RetriveByName)
 		authorized.GET("/sources", source.RetriveAll)
 
-		cohortdefinitions := controllers.NewCohortDefinitionController(*new(models.CohortDefinition))
+		cohortdefinitions := controllers.NewCohortDefinitionController(*new(models.CohortDefinition),
+			middlewares.NewTeamProjectAuthz(*new(models.CohortDefinition), &http.Client{}))
 		authorized.GET("/cohortdefinition/by-id/:id", cohortdefinitions.RetriveById)
 
 		authorized.GET("/cohortdefinition-stats/by-source-id/:sourceid/by-team-project", cohortdefinitions.RetriveStatsBySourceIdAndTeamProject)

--- a/tests/controllers_tests/controllers_test.go
+++ b/tests/controllers_tests/controllers_test.go
@@ -54,10 +54,10 @@ var cohortDataController = controllers.NewCohortDataController(*new(dummyCohortD
 var cohortDataControllerWithFailingTeamProjectAuthz = controllers.NewCohortDataController(*new(dummyCohortDataModel), *new(dummyFailingTeamProjectAuthz))
 
 // instance of the controller that talks to the regular model implementation (that needs a real DB):
-var cohortDefinitionControllerNeedsDb = controllers.NewCohortDefinitionController(*new(models.CohortDefinition))
+var cohortDefinitionControllerNeedsDb = controllers.NewCohortDefinitionController(*new(models.CohortDefinition), *new(dummyTeamProjectAuthz))
 
 // instance of the controller that talks to a mock implementation of the model:
-var cohortDefinitionController = controllers.NewCohortDefinitionController(*new(dummyCohortDefinitionDataModel))
+var cohortDefinitionController = controllers.NewCohortDefinitionController(*new(dummyCohortDefinitionDataModel), *new(dummyTeamProjectAuthz))
 
 type dummyCohortDataModel struct{}
 
@@ -151,6 +151,10 @@ func (h dummyTeamProjectAuthz) TeamProjectValidationForCohortIdsList(ctx *gin.Co
 	return true
 }
 
+func (h dummyTeamProjectAuthz) HasAccessToTeamProject(ctx *gin.Context, teamProject string) bool {
+	return true
+}
+
 type dummyFailingTeamProjectAuthz struct{}
 
 func (h dummyFailingTeamProjectAuthz) TeamProjectValidationForCohort(ctx *gin.Context, cohortDefinitionId int) bool {
@@ -162,6 +166,10 @@ func (h dummyFailingTeamProjectAuthz) TeamProjectValidation(ctx *gin.Context, co
 }
 
 func (h dummyFailingTeamProjectAuthz) TeamProjectValidationForCohortIdsList(ctx *gin.Context, uniqueCohortDefinitionIdsList []int) bool {
+	return false
+}
+
+func (h dummyFailingTeamProjectAuthz) HasAccessToTeamProject(ctx *gin.Context, teamProject string) bool {
 	return false
 }
 

--- a/tests/controllers_tests/controllers_test.go
+++ b/tests/controllers_tests/controllers_test.go
@@ -472,11 +472,31 @@ func TestRetriveStatsBySourceIdAndTeamProjectCheckMandatoryTeamProject(t *testin
 	}
 }
 
+func TestRetriveStatsBySourceIdAndTeamProjectAuthorizationError(t *testing.T) {
+	setUp(t)
+	requestContext := new(gin.Context)
+	requestContext.Params = append(requestContext.Params, gin.Param{Key: "sourceid", Value: strconv.Itoa(tests.GetTestSourceId())})
+	requestContext.Request = &http.Request{URL: &url.URL{}}
+	teamProject := "/test/dummyname/dummy-team-project"
+	requestContext.Request.URL.RawQuery = "team-project=" + teamProject
+	requestContext.Writer = new(tests.CustomResponseWriter)
+	cohortDefinitionControllerWithFailingTeamProjectAuthz.RetriveStatsBySourceIdAndTeamProject(requestContext)
+	result := requestContext.Writer.(*tests.CustomResponseWriter)
+	if !requestContext.IsAborted() {
+		t.Errorf("Expected aborted request")
+	}
+	if result.Status() != http.StatusForbidden {
+		t.Errorf("Expected StatusForbidden, got %d", result.Status())
+	}
+	if !strings.Contains(result.CustomResponseWriterOut, "access denied") {
+		t.Errorf("Expected 'access denied' in response")
+	}
+}
+
 func TestRetriveStatsBySourceIdAndTeamProject(t *testing.T) {
 	setUp(t)
 	requestContext := new(gin.Context)
 	requestContext.Params = append(requestContext.Params, gin.Param{Key: "sourceid", Value: strconv.Itoa(tests.GetTestSourceId())})
-	//requestContext.Params = append(requestContext.Params, gin.Param{Key: "teamproject", Value: "dummy-team-project"})
 	requestContext.Request = &http.Request{URL: &url.URL{}}
 	teamProject := "/test/dummyname/dummy-team-project"
 	requestContext.Request.URL.RawQuery = "team-project=" + teamProject

--- a/tests/middlewares_tests/middlewares_test.go
+++ b/tests/middlewares_tests/middlewares_test.go
@@ -145,7 +145,7 @@ func TestTeamProjectValidationForCohort(t *testing.T) {
 	}
 }
 
-func TestTeamProjectValidationForCohortPart2(t *testing.T) {
+func TestTeamProjectValidationForCohortArborist401(t *testing.T) {
 	setUp(t)
 	config.Init("mocktest")
 	arboristAuthzResponseCode := 401

--- a/tests/testutils.go
+++ b/tests/testutils.go
@@ -219,6 +219,7 @@ func Map[T, U any](items []T, f func(T) U) []U {
 // to use when mocking request context (gin.Context) in controller tests:
 type CustomResponseWriter struct {
 	CustomResponseWriterOut string
+	StatusCode              int
 }
 
 func (w *CustomResponseWriter) Header() http.Header {
@@ -234,7 +235,8 @@ func (w *CustomResponseWriter) Write(b []byte) (int, error) {
 }
 
 func (w *CustomResponseWriter) WriteHeader(statusCode int) {
-	// do nothing
+	// Store the status code
+	w.StatusCode = statusCode
 }
 
 func (w *CustomResponseWriter) CloseNotify() <-chan bool {
@@ -254,7 +256,7 @@ func (w *CustomResponseWriter) Pusher() (pusher http.Pusher) {
 }
 
 func (w *CustomResponseWriter) Status() int {
-	return 0
+	return w.StatusCode
 }
 
 func (w *CustomResponseWriter) Size() int {


### PR DESCRIPTION
Jira Ticket: [VADC-899](https://ctds-planx.atlassian.net/browse/VADC-899)

### Bug Fixes
- Add missing authorization checks for `RetriveStatsBySourceIdAndTeamProject` and `RetriveById` methods
- Ensure "access denied" errors return `StatusForbidden` instead of `StatusBadRequest`


[VADC-899]: https://ctds-planx.atlassian.net/browse/VADC-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ