### PR TITLE
fix: do not put data in "source_daimon" table

### DIFF
--- a/models/source.go
+++ b/models/source.go
@@ -43,6 +43,12 @@ type SourceSchema struct {
 }
 
 func (h Source) GetSourceSchemaNameBySourceIdAndSourceType(id int, sourceType SourceType) (*SourceSchema, error) {
+	// special handling of sourceType "Misc", as it is not stored in source_daimon table
+	if sourceType == Misc {
+		return &SourceSchema{SchemaName: "MISC"}, nil
+	}
+
+	// otherwise, get the schema name from source_daimon table
 	atlasDb := db.GetAtlasDB()
 	db2 := atlasDb.Db
 	var sourceSchema *SourceSchema

--- a/tests/setup_local_db/test_data_atlas.sql
+++ b/tests/setup_local_db/test_data_atlas.sql
@@ -14,8 +14,7 @@ values
     (1,1,0, 'OMOP', 1),
     (2,1,1, 'OMOP', 1),
     (3,1,2, 'RESULTS', 1),
-    (4,1,5, 'TEMP', 1),
-    (5,1,6, 'MISC', 1)
+    (4,1,5, 'TEMP', 1)
 ;
 
 insert into atlas.cohort_definition


### PR DESCRIPTION


Link to JIRA ticket if there is one: [VADC-1135](https://ctds-planx.atlassian.net/browse/VADC-1135)

### New Features

### Breaking Changes

### Bug Fixes
* WebAPI doesn't support `daimon_type` equal to 6, because of [this](https://github.com/uc-cdis/WebAPI/blob/f23606c97591469b1dc61406226158407dddf5f2/src/main/java/org/ohdsi/webapi/source/SourceDaimon.java#L45)

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[VADC-1135]: https://ctds-planx.atlassian.net/browse/VADC-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ