### PR TITLE
Feat/improve global cohort logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ gen3 kube-setup-cohort-middleware
 
 The script will use `ohdsi` database credentials and will result in `cohort-middleware-g3auto` Kubernetes secret.
 
+If any changes need to be made to the settings, find the .yaml config file:
+
+```
+find ~ -type f -path '*/g3auto/cohort-middleware/*.yaml'
+```
+and **remove** that first before running the `gen3 kube-setup` command above.
+
 ### Roll cohort-middleware
 
 To roll cohort-middleware (in case of version update), full `kube-setup-cohort-middleware` is not required:

--- a/controllers/cohortdefinition.go
+++ b/controllers/cohortdefinition.go
@@ -81,6 +81,7 @@ func (u CohortDefinitionController) RetriveStatsBySourceIdAndTeamProject(c *gin.
 		// so also include cohorts from there:
 		conf := config.GetConfig()
 		globalReaderRole := conf.GetString("global_reader_role")
+		log.Printf("INFO: found %s as global_reader_role", globalReaderRole)
 		globalCohortDefinitionsAndStats, err := u.cohortDefinitionModel.GetAllCohortDefinitionsAndStatsOrderBySizeDesc(sourceId, globalReaderRole)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"message": "Error retrieving cohortDefinition for 'global reader' role", "error": err.Error()})

--- a/middlewares/teamprojectauthz.go
+++ b/middlewares/teamprojectauthz.go
@@ -82,8 +82,11 @@ func (u TeamProjectAuthz) TeamProjectValidation(ctx *gin.Context, cohortDefiniti
 
 // "team project" related checks:
 // (1) check if any cohorts belong to the "global reader role"
-//    (1.1) if yes, check if user has permission for the "global reader role"
-// (2) check if all cohorts (except the ones from (1) above) belong to the same "team project"
+//
+//		(1.1) if yes, check if ALL cohorts belong to the "global reader role".
+//	       If so, return true.
+//
+// (2) check if all remaining cohorts belong to the same "team project"
 // (3) check if the user has permission in the "team project"
 // Returns true if all checks above pass, false otherwise.
 func (u TeamProjectAuthz) TeamProjectValidationForCohortIdsList(ctx *gin.Context, uniqueCohortDefinitionIdsList []int) bool {
@@ -101,14 +104,9 @@ func (u TeamProjectAuthz) TeamProjectValidationForCohortIdsList(ctx *gin.Context
 	// and for the following checks, filter out the cohorts associated with 'global reader role':
 	cohortDefinitionIdsToCheck := utils.Subtract(uniqueCohortDefinitionIdsList, globalCohortDefinitionIds)
 	if len(overlapWithGlobal) > 0 {
-		// one or more cohortDefinitionIds are part of globalReaderRole. Check if user has been granted this role:
-		if !u.HasAccessToTeamProject(ctx, globalReaderRole) {
-			// unauthorized:
-			log.Printf("Invalid request error: NO access to 'global reader role'!")
-			return false
-		}
+		// one or more cohortDefinitionIds are part of globalReaderRole. Check if all of them are global:
 		if len(cohortDefinitionIdsToCheck) == 0 {
-			// all cohortDefinitionIds are global, and user passed the access to global role test above,
+			// all cohortDefinitionIds are global,
 			// so return true:
 			return true
 		}

--- a/tests/middlewares_tests/middlewares_test.go
+++ b/tests/middlewares_tests/middlewares_test.go
@@ -211,8 +211,8 @@ func TestTeamProjectValidationFullOverlapWithGlobalCohorts(t *testing.T) {
 	if result == false {
 		t.Errorf("Expected TeamProjectValidation result to be 'true'")
 	}
-	if dummyHttpClient.nrCalls != 1 {
-		t.Errorf("Expected dummyHttpClient to have been called only once")
+	if dummyHttpClient.nrCalls != 0 {
+		t.Errorf("Expected dummyHttpClient to not have been called, got %d calls", dummyHttpClient.nrCalls)
 	}
 }
 
@@ -257,8 +257,8 @@ func TestTeamProjectValidationPartialOverlapWithGlobalCohorts(t *testing.T) {
 	if result == false {
 		t.Errorf("Expected TeamProjectValidation result to be 'true'")
 	}
-	if dummyHttpClient.nrCalls != 2 {
-		t.Errorf("Expected dummyHttpClient to have been called twice, but got %d", dummyHttpClient.nrCalls)
+	if dummyHttpClient.nrCalls != 1 {
+		t.Errorf("Expected dummyHttpClient to have been called once, but got %d", dummyHttpClient.nrCalls)
 	}
 }
 
@@ -303,30 +303,6 @@ func TestTeamProjectValidationArborist401ForTeamProject(t *testing.T) {
 	}
 	if dummyHttpClient.nrCalls <= 1 {
 		t.Errorf("Expected dummyHttpClient to have been called more than once")
-	}
-}
-
-func TestTeamProjectValidationArborist401ForGlobalRoleAfterOverlap(t *testing.T) {
-	setUp(t)
-	config.Init("mocktest")
-	arboristAuthzResponseCode := 401
-	dummyHttpClient := &dummyHttpClient{statusCode: arboristAuthzResponseCode}
-	// ensure overlap between global and cohorts to check, so authz on global role is checked first thing in TeamProjectValidation:
-	globalCohorts := []int{1, 2}
-	cohortsToCheck := []int{1, 2}
-	teamProjectAuthz := middlewares.NewTeamProjectAuthz(&dummyCohortDefinitionDataModel{returnForGetCohortDefinitionIdsForTeamProject: globalCohorts},
-		dummyHttpClient)
-	requestContext := new(gin.Context)
-	requestContext.Request = new(http.Request)
-	requestContext.Request.Header = map[string][]string{
-		"Authorization": {"dummy_token_value"},
-	}
-	result := teamProjectAuthz.TeamProjectValidation(requestContext, cohortsToCheck, nil)
-	if result == true {
-		t.Errorf("Expected TeamProjectValidation result to be 'false'")
-	}
-	if dummyHttpClient.nrCalls != 1 {
-		t.Errorf("Expected dummyHttpClient to have been called only once")
 	}
 }
 


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-1063

### Bug Fixes
- Fix: allow access to globally shared cohorts without checking Arborist (continued from https://github.com/uc-cdis/cohort-middleware/pull/105)
### Improvements
- Improved README to document how to redeploy configuration changes
- Improved some logging around `global_reader_role`